### PR TITLE
Fix PHP 8.4 deprecations

### DIFF
--- a/classes/mageekguy/atoum.php
+++ b/classes/mageekguy/atoum.php
@@ -225,7 +225,7 @@ class atoum extends mageekguy\atoum\test
      *
      * @return object
      */
-    public function newMockInstance($class, $mockNamespace = null, $mockClass = null, array $constructorArguments = null) {}
+    public function newMockInstance($class, $mockNamespace = null, $mockClass = null, ?array $constructorArguments = null) {}
 
 	/**
 	 * Allow to initialize the execution environment of the individual tests for all test method of the class.

--- a/classes/mageekguy/atoum/stubs/asserters/exception.php
+++ b/classes/mageekguy/atoum/stubs/asserters/exception.php
@@ -192,5 +192,5 @@ class exception extends phpObject
      *
      * @return $this
      */
-    public function hasNestedException(\exception $exception = null, $failMessage = null) {}
+    public function hasNestedException(?\exception $exception = null, $failMessage = null) {}
 }


### PR DESCRIPTION
When a parameter is defined like `type $name = null`, it is implicitely nullable. This has been deprecated in PHP 8.4 to force the explicit nullable declaration, e.g. `?type $name = null`.

As the nullable state was implicit, changing this does not result in any BC break.